### PR TITLE
Use non-recursive mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ You also have the option to cancel the default mappings and create the mappings 
 let g:unicoder_cancel_normal = 1
 let g:unicoder_cancel_insert = 1
 let g:unicoder_cancel_visual = 1
-nmap <C-l> :call unicoder#start(0)<CR>
-imap <C-l> <Esc>:call unicoder#start(1)<CR>
-vmap <C-l> :<C-u>call unicoder#selection()<CR>
+nnoremap <C-l> :call unicoder#start(0)<CR>
+inoremap <C-l> <Esc>:call unicoder#start(1)<CR>
+vnoremap <C-l> :<C-u>call unicoder#selection()<CR>
 ```
 
 ## Contributions

--- a/plugin/unicoder.vim
+++ b/plugin/unicoder.vim
@@ -2,11 +2,11 @@
 " http://github.com/joom/latex-unicoder.vim
 
 if !exists("g:unicoder_cancel_normal")
-  nmap <C-l> :call unicoder#start(0)<CR>
+  nnoremap <C-l> :call unicoder#start(0)<CR>
 endif
 if !exists("g:unicoder_cancel_insert")
-  imap <C-l> <Esc>:call unicoder#start(1)<CR>
+  inoremap <C-l> <Esc>:call unicoder#start(1)<CR>
 endif
 if !exists("g:unicoder_cancel_visual")
-  vmap <C-l> :<C-u>call unicoder#selection()<CR>
+  vnoremap <C-l> :<C-u>call unicoder#selection()<CR>
 endif


### PR DESCRIPTION
Plugins should provide non-recursive mappings in order to work regardless of any other mappings a user has defined ([more info here](http://learnvimscriptthehardway.stevelosh.com/chapters/05.html)).

In particular here, I map `<esc>` to `<nop>` in insert mode (which is a pretty common mapping, I think), so without this change, pressing `<C-l>` just inserts the text `:call unicoder#start(1)` into the buffer and starts a new line.