### PR TITLE
Replacement of multiple latex codes at once

### DIFF
--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2505,28 +2505,22 @@ let s:symbols = {
   \ }
 
 
+function! unicoder#lookup_char(char)
+  if has_key(s:symbols, a:char)
+    return s:symbols[a:char]
+  else
+    return a:char
+  endif
+endfunction
+
+
 function! unicoder#transform_string(code)
   " handle the case when there are now latex commands at all
   if match(a:code, '\\') == -1
     return a:code
   endif
 
-  " TODO: handle a string like 'asdf \alpha asdf' or 'asdf-\alpha'
-
-  let res = ''
-  for expr in split(a:code, '\\')
-    let CMDREGEX = '\(\S\+\)\(\s*.*\)'
-    let item = '\' . substitute(expr, CMDREGEX, '\1', '')
-    let rem = substitute(expr, CMDREGEX, '\2', '')
-
-    if has_key(s:symbols, item)
-      let res = res . s:symbols[item] . rem
-    else
-      let res = res . item . rem
-    endif
-  endfor
-
-  return res
+  return substitute(a:code, '\(\\\S\+\)', '\=unicoder#lookup_char(submatch(1))', 'g')
 
 endfunction
 


### PR DESCRIPTION
The use case is that you might want to write more than one latex code at once, maybe even a small formula, like you would do in a latex math environment. 
i.e. type ` \forall \alpha \in A : \exists a \in A : a \cdot \alpha = 1 ` and then unicode it, either by typing it directly into the prompt or selecting the whole formula in visual mode. Doing it character for character is kind of annoying.

I quickly hacked together the functionality to replace multiple latex codes at once, which seems to work pretty well. It doesn't break auto-completion for the first code, but for all following auto-completion doesn't work anymore.

Note that this was basically my first attempt at vimscript so please excuse any obvious errors.