### PR TITLE
Various regex fixes regarding multiple code replacement

### DIFF
--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2516,7 +2516,7 @@ endfunction
 
 function! unicoder#transform_string(code)
 
-  return substitute(a:code, '\([\_\^\\]\S\+\)', '\=unicoder#lookup_char(submatch(1))', 'g')
+  return substitute(a:code, '\([\_\^\\][^\\\_\^ \t\n\r]\+\)', '\=unicoder#lookup_char(submatch(1))', 'g')
 
 endfunction
 

--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2547,7 +2547,6 @@ function! unicoder#start_complete(a, c, p)
 endfunction
 
 function! unicoder#selection()
-  " TODO: there is a problem with this when a whole line is selected
   normal! gv"xy
   let @x = unicoder#transform_string(@x)
   normal! gv"xp

--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2515,12 +2515,8 @@ endfunction
 
 
 function! unicoder#transform_string(code)
-  " handle the case when there are now latex commands at all
-  if match(a:code, '\\') == -1
-    return a:code
-  endif
 
-  return substitute(a:code, '\(\\\S\+\)', '\=unicoder#lookup_char(submatch(1))', 'g')
+  return substitute(a:code, '\([\_\^\\]\S\+\)', '\=unicoder#lookup_char(submatch(1))', 'g')
 
 endfunction
 


### PR DESCRIPTION
This fixes several bugs, introduced by my previous pull request https://github.com/joom/latex-unicoder.vim/pull/5

'\alpha\beta' was not replaced correctly
'\alpha<newline>' was not replaced correctly, this introduced problems when selecting whole lines in visual mode.

Replacement of normal letters like  "a" with their cursive equivalent "𝑎", is still unsupported/broken. Imho this should be configurable.