### PR TITLE
Fix flipped return logic in unicode insert

### DIFF
--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2533,7 +2533,7 @@ function! unicoder#start(insert)
   let s = unicoder#transform_string(code)
   execute 'normal! ' . how . s
 
-  if a:insert <= 0
+  if a:insert > 0
     startinsert!
     normal! l
   endif


### PR DESCRIPTION
Normal mode call was entering insert mode and insert mode call was exiting insert mode.