### PR TITLE
Replace <Esc> with <C-o>

### DIFF
--- a/plugin/unicoder.vim
+++ b/plugin/unicoder.vim
@@ -5,7 +5,7 @@ if !exists("g:unicoder_cancel_normal")
   nnoremap <Plug>Unicoder :call unicoder#start(0)<CR>
 endif
 if !exists("g:unicoder_cancel_insert")
-  inoremap <Plug>Unicoder <Esc>:call unicoder#start(1)<CR>
+  inoremap <Plug>Unicoder <C-o>:call unicoder#start(1)<CR>
 endif
 if !exists("g:unicoder_cancel_visual")
   vnoremap <Plug>Unicoder :<C-u>call unicoder#selection()<CR>


### PR DESCRIPTION
Switching to \<C-o> fixes a problem I had with the plugin not actually working in insert mode. This is also the recommended way to handle mappings in insert mode. 

Source: http://vim.wikia.com/wiki/Use_Ctrl-O_instead_of_Esc_in_insert_mode_mappings