### PR TITLE
Position cursor after inserted characters

### DIFF
--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2591,6 +2591,7 @@ function! unicoder#start(insert)
   let code = input('Enter symbol code (add "\" if required) : ', '', 'customlist,unicoder#start_complete')
 
   if a:insert > 0
+    let isend = col('.') == col('$') - 1
     let how = 'a'
   else
     let how = 'i'
@@ -2600,8 +2601,12 @@ function! unicoder#start(insert)
   execute 'normal! ' . how . s
 
   if a:insert > 0
-    startinsert!
-    normal! l
+    if isend
+      startinsert!
+    else
+      startinsert
+      normal! l
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
`startinsert!` unconditionally moves the cursor to the end of the line which is wrong if editing inside a line.

Related to #10 

e.g.

```
iade<Esc>
^
a<C-l>\beta<CR>c
```

Should result in `aβcde` but currently inserts `aβdec`.

Note that this still isn't perfect:

```
icde<Esc>
^
i<C-l>\alpha<CR>b
```

Should result in `αbcde` but currently inserts `cαbde`.  This is because I can't tell insert apart from append, and so mangle inserts in the first column. Unfortunately my Google-fu wasn't enough to work out how to distinguish how we got into insert mode.