### PR TITLE
add option to add custom symbols in vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ inoremap <C-l> <Esc>:call unicoder#start(1)<CR>
 vnoremap <C-l> :<C-u>call unicoder#selection()<CR>
 ```
 
+You can add additional custom symbols by defining `g:unicode_map` in your `.vimrc`, for instance:
+```vim
+let g:unicode_map = {
+  \ "\\box" : "□" ,
+  \ "\\sep" : "∗" ,
+  \ }
+```
+
 ## Contributions
 
 There might be certain symbols and aliases that I miss. Pull requests are welcome. If you have other suggestions about the plugin usage, I'd like to hear them as well.

--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -1,7 +1,7 @@
 " LaTeX Unicoder.vim
 " http://github.com/joom/latex-unicoder.vim
 
-let s:symbols = {
+let s:presymbols = {
   \  "0"                          : "0",
   \  "1"                          : "1",
   \  "2"                          : "2",
@@ -2503,6 +2503,11 @@ let s:symbols = {
   \  "\frac{1}{4}"                : "¼",
   \  "\frac{3}{4}"                : "¾"
   \ }
+
+if !exists("g:unicode_map")
+  let g:unicode_map = {}
+endif
+let s:symbols = extend(s:presymbols, g:unicode_map)
 
 " Construct a trie from the s:symbols map to allow for efficient searches for
 " the longest matching prefix


### PR DESCRIPTION
Hi, thanks for this very useful project!

This PR adds an option to add custom symbols to the vimrc, which for me is very useful both to add symbols that are not available by default and to have names that are easier to memorize (by giving names that indicate how I use the symbol semantically). 
I've been using the plugin with this modification for some time now.

Best,
Lennard

