### PR TITLE
Fix insertion mode

### DIFF
--- a/plugin/unicoder.vim
+++ b/plugin/unicoder.vim
@@ -13,5 +13,7 @@ endif
 
 if !exists("g:unicoder_no_map")
     " we _don't_ want noremap here -- we _need_ <Plug>Unicoder to get recursed
-    map <C-l> <Plug>Unicoder
+    nmap <C-l> <Plug>Unicoder
+    imap <C-l> <Plug>Unicoder
+    vmap <C-l> <Plug>Unicoder
 endif


### PR DESCRIPTION
Commit 7d28234e changed :{n,i,v}noremap mappings effectively to a :map.
However, :map does not apply to insert mode. Change :map to :{n,i,v}map
to restore the old behavior.

Fixes issue #23.