### PR TITLE
Attempt to fix insert mode positioning

### DIFF
--- a/autoload/unicoder.vim
+++ b/autoload/unicoder.vim
@@ -2657,8 +2657,12 @@ function! unicoder#start(insert)
   let code = input('Enter symbol code (add "\" if required) : ', '', 'customlist,unicoder#start_complete')
 
   if a:insert > 0
-    let isend = col('.') == col('$') - 1
-    let how = 'a'
+    let isend = col('.') == col('$')
+    if isend
+      let how = 'a'
+    else
+      let how = 'i'
+    endif
   else
     let how = 'i'
   endif
@@ -2674,6 +2678,7 @@ function! unicoder#start(insert)
       normal! l
     endif
   endif
+  return ""
 endfunction
 
 function! unicoder#start_complete(a, c, p)

--- a/plugin/unicoder.vim
+++ b/plugin/unicoder.vim
@@ -1,11 +1,12 @@
 " LaTeX Unicoder.vim
 " http://github.com/joom/latex-unicoder.vim
 
+
 if !exists("g:unicoder_cancel_normal")
   nnoremap <Plug>Unicoder :call unicoder#start(0)<CR>
 endif
 if !exists("g:unicoder_cancel_insert")
-  inoremap <Plug>Unicoder <C-o>:call unicoder#start(1)<CR>
+  inoremap <Plug>Unicoder <C-R>=unicoder#start(1)<CR>
 endif
 if !exists("g:unicoder_cancel_visual")
   vnoremap <Plug>Unicoder :<C-u>call unicoder#selection()<CR>


### PR DESCRIPTION
This tries to fix multiple issues I've encountered with insert mode positioning:
- when on the last character of a line, entering insert mode via `i` or `a` and then calling latex-unicoder results in the same insert position, since the positioning check does not determine correctly what the last insert position was (see also https://github.com/joom/latex-unicoder.vim/issues/25).
- when entering insert mode in a new line with `o` and then directly calling latex-unicoder, the plugin does not respect the correct indentation that would normally be observed by `o`, and instead inserts the unicode symbol at position 0.

From my testing, the changes introduced by this PR work well, but I've only tested with `nvim` under MacOS, so this may potentially introduce problems under other platforms -- not sure.